### PR TITLE
Add support for Mongoid 3 and 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 .bundle
 Gemfile.lock
+coverage
 pkg/*
 .rvmrc

--- a/lib/mongoid/metastamp/time.rb
+++ b/lib/mongoid/metastamp/time.rb
@@ -1,59 +1,74 @@
-# encoding: utf-8
-
 module Mongoid #:nodoc:
   module Metastamp
-    class Time
-      include Mongoid::Fields::Serializable
-      include Mongoid::Fields::Internal::Timekeeping
+    class Time < ::Time
 
-      def deserialize(object)
-        return nil if object.blank?
-        return super(object) if object.instance_of?(::Time)
-        time = object['time'].getlocal unless Mongoid::Config.use_utc?
-        zone = ActiveSupport::TimeZone[object['zone']]
-        zone = ActiveSupport::TimeZone[object['offset']] if zone.nil?
-        time.in_time_zone(zone)
-      end
+      class << self
 
-      def serialize(object)
-        return nil if object.blank?
-        time = super(object)
-        local_time = time.in_time_zone(::Time.zone)
-        { 
-          time:         time,
-          normalized:   normalized_time(local_time),
-          year:         local_time.year,
-          month:        local_time.month,
-          day:          local_time.day,
-          wday:         local_time.wday,
-          hour:         local_time.hour,
-          min:          local_time.min,
-          sec:          local_time.sec,
-          zone:         ::Time.zone.name,
-          offset:       local_time.utc_offset
-        }.stringify_keys
-      end
-
-    protected
-
-      def parse_datetime(value)
-        case value
-          when ::String
-            ::DateTime.parse(value)
-          when ::Time
-            offset = ActiveSupport::TimeZone.seconds_to_utc_offset(value.utc_offset)
-            ::DateTime.new(value.year, value.month, value.day, value.hour, value.min, value.sec, offset)
-          when ::Date
-            ::DateTime.new(value.year, value.month, value.day)
-          when ::Array
-            ::DateTime.new(*value)
-          else
-            value
+        # Get the time object from its mongo friendly ruby type to this time type.
+        #
+        # @example Demongoize the object.
+        #   Mongoid::Metastamp::Time.demongoize(object)
+        #
+        # @param [ Object ] The object to demongoize.
+        #
+        # @return [ ActiveSupport::TimeWithZone ] The time object.
+        def demongoize(object)
+          return nil if object.blank?
+          return super(object) if object.instance_of?(::Time)
+          time = object['time'].getlocal unless Mongoid::Config.use_utc?
+          zone = ActiveSupport::TimeZone[object['zone']]
+          zone = ActiveSupport::TimeZone[object['offset']] if zone.nil?
+          time.in_time_zone(zone)
         end
-      end
 
-      def normalized_time(time)
-        ::Time.parse("#{ time.strftime("%F %T") } -0000").utc
+        # Turn the object from the ruby type we deal with to a Mongo friendly
+        # type.
+        #
+        # @example Mongoize the object.
+        #   Mongoid::Metastamp::Time.mongoize(Time.now)
+        #
+        # @param [ Object ] The object to mongoize.
+        #
+        # @return [ Hash ] The mongoized object.
+        def mongoize(object)
+          return nil if object.blank?
+          time = super(object)
+          local_time = time.in_time_zone(::Time.zone)
+          {
+            time:         time,
+            normalized:   normalized_time(local_time),
+            year:         local_time.year,
+            month:        local_time.month,
+            day:          local_time.day,
+            wday:         local_time.wday,
+            hour:         local_time.hour,
+            min:          local_time.min,
+            sec:          local_time.sec,
+            zone:         ::Time.zone.name,
+            offset:       local_time.utc_offset
+          }.stringify_keys
+        end
+
+        # Evolve the object into a mongo-friendly value to query with.
+        #
+        # @example Evolve the object.
+        #   Mongoid::Metastamp::Time.evolve(object)
+        #
+        # @param [ Object ] The object to evolve.
+        #
+        # @return [ Object ] The evolved object.
+        def evolve(object)
+          case object
+          when Date, Time, ActiveSupport::TimeWithZone then { "time" => object.mongoize }
+          else object
+          end
+        end
+
+      protected
+
+        def normalized_time(time)
+          ::Time.parse("#{ time.strftime("%F %T") } -0000").utc
+        end
       end
     end
   end

--- a/lib/mongoid/metastamp/time.rb
+++ b/lib/mongoid/metastamp/time.rb
@@ -37,6 +37,7 @@ module Mongoid #:nodoc:
           {
             time:         time,
             normalized:   normalized_time(local_time),
+            cweek:        local_time.to_date.cweek,
             year:         local_time.year,
             month:        local_time.month,
             day:          local_time.day,

--- a/mongoid-metastamp.gemspec
+++ b/mongoid-metastamp.gemspec
@@ -19,7 +19,9 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("mongoid", "~> 2.4")
+  s.add_dependency("mongoid", "~> 3.0.0")
   s.add_development_dependency("rake", "~> 0.9")
   s.add_development_dependency("rspec", "~> 2.6")
+  s.add_development_dependency("database_cleaner", "~> 1.4.0")
+  s.add_development_dependency("pry", "~> 0.10.0")
 end

--- a/mongoid-metastamp.gemspec
+++ b/mongoid-metastamp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("mongoid", "~> 3.0.0")
+  s.add_dependency("mongoid", ">= 3.0.0", '<= 4.1')
   s.add_development_dependency("rake", "~> 0.9")
   s.add_development_dependency("rspec", "~> 2.6")
   s.add_development_dependency("database_cleaner", "~> 1.4.0")

--- a/mongoid-metastamp.gemspec
+++ b/mongoid-metastamp.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rspec", "~> 2.6")
   s.add_development_dependency("database_cleaner", "~> 1.4.0")
   s.add_development_dependency("pry", "~> 0.10.0")
+  s.add_development_dependency 'simplecov', ">= 0.10.0"
+  s.add_development_dependency 'codeclimate-test-reporter', '0.4.7'
 end

--- a/spec/config/mongoid.yml
+++ b/spec/config/mongoid.yml
@@ -1,0 +1,16 @@
+# Tell Mongoid which environment this configuration is for.
+test:
+  # Configure available database sessions. (required)
+  sessions:
+    # Defines the default session. (required)
+    default:
+      # Defines the name of the default database that Mongoid can connect to.
+      # (required).
+      database: mongoid_metastamp_test
+      # Provides the hosts the default session can connect to. Must be an array
+      # of host:port pairs. (required)
+      hosts:
+        - localhost:27017
+  options:
+    use_activesupport_time_zone: true
+    use_utc: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,15 +6,14 @@ require "mongoid"
 require "mongoid/metastamp"
 require "mongoid/metastamp/time"
 
+require 'database_cleaner'
+require 'pry'
+
 require "rspec"
 
 Zonebie.set_random_timezone
 
-Mongoid.configure do |config|
-  config.master = Mongo::Connection.new.db("mongoid_metastamp_test")
-  config.use_utc = false
-  config.use_activesupport_time_zone = true
-end
+Mongoid.load!("#{File.dirname(__FILE__)}/config/mongoid.yml", :test)
 
 Dir["#{File.dirname(__FILE__)}/models/*.rb"].each { |f| require f }
 
@@ -24,6 +23,6 @@ RSpec.configure do |c|
   end
 
   c.before :each do
-    Mongoid.master.collections.select {|c| c.name !~ /system/ }.each(&:remove)
+    DatabaseCleaner.clean
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,17 @@
+require 'codeclimate-test-reporter'
+require 'simplecov'
+
+formatters = [SimpleCov::Formatter::HTMLFormatter]
+if ENV['CODECLIMATE_REPO_TOKEN']
+  formatters << CodeClimate::TestReporter::Formatter
+  CodeClimate::TestReporter.start
+end
+
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[*formatters]
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
 require "rubygems"
 require "bundler/setup"
 require "zonebie"

--- a/spec/time_compatibility_spec.rb
+++ b/spec/time_compatibility_spec.rb
@@ -30,7 +30,7 @@ describe "Mongoid::Metastamp::Time" do
       end
 
       it "should contain the same timestamp" do
-        instance.timestamp.should == now.to_s
+        format_time(instance.timestamp).should == format_time(now)
       end
 
     end
@@ -47,7 +47,7 @@ describe "Mongoid::Metastamp::Time" do
       end
 
       it "should still be able to read legacy timestamps" do
-        legacy.timestamp.should == now.to_s
+        format_time(legacy.timestamp).should == format_time(now)
       end
       
       describe "updating timestamp with the same time" do
@@ -61,12 +61,12 @@ describe "Mongoid::Metastamp::Time" do
         end
 
         it "should still be compatible with the legacy timestamp" do
-          legacy.timestamp.should == now.to_s
+          format_time(legacy.timestamp).should == format_time(now)
         end
 
         it "should still store timestamp as a Time" do
           legacy['timestamp']['time'].class.should == Time
-          legacy['timestamp']['time'].should == now.to_s
+          legacy['timestamp']['time'] == now.to_time
         end
 
         it "should still return timestamp as an ActiveSupport::TimeWithZone" do
@@ -75,6 +75,15 @@ describe "Mongoid::Metastamp::Time" do
 
       end
 
+    end
+
+    # Below mehotd avoids that time-with-zone comparison fails due of hidden
+    # millisecond differences
+    # @param time [TimeWithZone]
+    # @return [String], formatted time with zone
+    def format_time(time)
+      strftime_preset = '%Y-%m-%dT%l:%M:%S%z'
+      time.strftime(strftime_preset)
     end
 
   end


### PR DESCRIPTION
Hi there,
sorry my english is not the best around, as you mentioned before in the issue #1, I have made some modifications in order to support both mongoid 3 and 4 gem versions (all tests are green now); also, I have added the code climate support but the badges are still missing (I would like to add them), finally the gem version (for mongoid-metastamp) needs to be updated.
Best,
